### PR TITLE
Rename fake-factory to faker

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,8 @@ faker_ integration the pytest_ test runner
 
 pytest-faker adds faker fixtures_ for easy use of faker_ for your tests under pytest_ runner.
 
-.. _faker: http://www.joke2k.net/faker/
 .. _pytest: http://pytest.org
+.. _Faker: https://faker.readthedocs.io/
 .. _fixtures: https://pytest.org/latest/fixture.html
 
 Install pytest-faker

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-faker_ integration the pytest_ test runner
+Faker_ integration with the pytest_ test runner
 ==========================================
 
 .. image:: https://api.travis-ci.org/pytest-dev/pytest-faker.png
@@ -11,10 +11,10 @@ faker_ integration the pytest_ test runner
     :target: https://readthedocs.org/projects/pytest-faker/?badge=latest
     :alt: Documentation Status
 
-pytest-faker adds faker fixtures_ for easy use of faker_ for your tests under pytest_ runner.
+pytest-faker adds Faker fixtures_ for easy use of Faker_ for your tests under pytest_ runner.
 
-.. _pytest: http://pytest.org
 .. _Faker: https://faker.readthedocs.io/
+.. _pytest: http://pytest.org/
 .. _fixtures: https://pytest.org/latest/fixture.html
 
 Install pytest-faker
@@ -27,7 +27,7 @@ Install pytest-faker
 Example
 -------
 
-An example of faker_ and pytest_ integration.
+An example of Faker_ and pytest_ integration.
 
 
 tests/test_faker.py:

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "Programming Language :: Python :: 3"
     ] + [("Programming Language :: Python :: %s" % x) for x in "2.6 2.7 3.0 3.1 3.2 3.3 3.4".split()],
     install_requires=[
-        "fake-factory",
+        "Faker>=0.7.3",
     ],
     # the following makes a plugin available to py.test
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ long_description = (
 
 setup(
     name="pytest-faker",
-    description="Faker integration for pytest framework.",
+    description="Faker integration with the pytest framework.",
     long_description=long_description,
     author="Anatoly Bubenkov, Oleg Pidsadnyi and others",
     license="MIT license",

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps = -r{toxinidir}/requirements-testing.txt
 
 [testenv:py26]
 deps =
-    git+https://github.com/joke2k/faker.git#egg=fake-factory
+    git+https://github.com/joke2k/faker.git#egg=Faker
     -r{toxinidir}/requirements-testing.txt
 
 [testenv:coveralls]


### PR DESCRIPTION
This needs to be merged by Dec 15th, as the `fake-factory` namespace will stop shipping a functional package then. cc @nicoddemus

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-faker/3)
<!-- Reviewable:end -->
