### PR TITLE
Use flake8 instead of pep8.

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,4 +1,4 @@
 mock
-pytest-pep8
+pytest-flake8
 pytest-cov
 pytest-cache

--- a/tox.ini
+++ b/tox.ini
@@ -18,5 +18,5 @@ commands =
     coveralls
 
 [pytest]
-addopts = -vv -l --pep8
-pep8maxlinelength = 120
+addopts = -vv -l --flake8
+flake8-max-line-length = 120


### PR DESCRIPTION
Pep8 is a deprecated package that was replaced by pycodestyle.
Flake8 runs pycodestyle.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-faker/8)
<!-- Reviewable:end -->
